### PR TITLE
fix(ci): restore macOS release notarization path

### DIFF
--- a/.github/workflows/publish-tauri-macos.yml
+++ b/.github/workflows/publish-tauri-macos.yml
@@ -29,8 +29,8 @@
 #     APPLE_PASSWORD
 #     APPLE_TEAM_ID
 #   App Store Connect API flow:
-#     APPLE_API_KEY        — App Store Connect key ID
-#     APPLE_API_ISSUER     — issuer UUID (team keys only)
+#     APPLE_API_KEY         — App Store Connect Team Key ID
+#     APPLE_API_ISSUER      — issuer UUID shown above Team Keys in App Store Connect
 #     APPLE_API_PRIVATE_KEY — raw `.p8` private key contents
 #
 # ── OTA Hosting ──────────────────────────────────────────────────
@@ -69,6 +69,16 @@ env:
 jobs:
   build-macos:
     runs-on: macos-latest
+    env:
+      APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE || '' }}
+      APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD || '' }}
+      APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '' }}
+      APPLE_ID: ${{ secrets.APPLE_ID || '' }}
+      APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || '' }}
+      APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID || '' }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY || '' }}
+      APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER || '' }}
+      APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY || '' }}
     defaults:
       run:
         working-directory: ui
@@ -107,9 +117,6 @@ jobs:
 
       - name: Import Apple certificate
         if: env.APPLE_CERTIFICATE != ''
-        env:
-          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
-          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
           CERT_PATH=$RUNNER_TEMP/certificate.p12
           KEYCHAIN_PATH=$RUNNER_TEMP/app-signing.keychain-db
@@ -127,10 +134,7 @@ jobs:
           security list-keychain -d user -s "$KEYCHAIN_PATH"
 
       - name: Materialize App Store Connect API key
-        if: ${{ secrets.APPLE_API_PRIVATE_KEY != '' }}
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
+        if: env.APPLE_API_PRIVATE_KEY != ''
         run: |
           if [ -z "${APPLE_API_KEY:-}" ]; then
             echo "::error::APPLE_API_KEY secret is required when APPLE_API_PRIVATE_KEY is configured."
@@ -141,6 +145,40 @@ jobs:
           printf '%s' "$APPLE_API_PRIVATE_KEY" > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
           echo "APPLE_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+
+      - name: Validate notarization credentials
+        run: |
+          if [ -n "${APPLE_ID:-}${APPLE_PASSWORD:-}${APPLE_TEAM_ID:-}" ]; then
+            if [ -z "${APPLE_ID:-}" ] || [ -z "${APPLE_PASSWORD:-}" ] || [ -z "${APPLE_TEAM_ID:-}" ]; then
+              echo "::error::Apple ID notarization requires APPLE_ID, APPLE_PASSWORD, and APPLE_TEAM_ID together."
+              exit 1
+            fi
+
+            echo "Using Apple ID notarization flow."
+            exit 0
+          fi
+
+          if [ -n "${APPLE_API_KEY:-}${APPLE_API_PRIVATE_KEY:-}${APPLE_API_ISSUER:-}" ]; then
+            if [ -z "${APPLE_API_KEY:-}" ] || [ -z "${APPLE_API_KEY_PATH:-}" ]; then
+              echo "::error::App Store Connect notarization requires APPLE_API_KEY and a materialized APPLE_API_KEY_PATH."
+              exit 1
+            fi
+
+            if [ -z "${APPLE_API_ISSUER:-}" ]; then
+              echo "::error::APPLE_API_ISSUER is missing. Use the issuer UUID from App Store Connect > Users and Access > Integrations > Team Keys."
+              exit 1
+            fi
+
+            if ! [[ "${APPLE_API_ISSUER}" =~ ^[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}$ ]]; then
+              echo "::error::APPLE_API_ISSUER must be the Team Key issuer UUID, not the 10-character Apple Team ID."
+              exit 1
+            fi
+
+            echo "Using App Store Connect Team Key notarization flow."
+            exit 0
+          fi
+
+          echo "No notarization credentials configured; build will proceed without notarization."
 
       # ── Build ──────────────────────────────────────────────────
 
@@ -171,15 +209,17 @@ jobs:
           fi
 
       - name: Build Tauri app
-        env:
-          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY || '' }}
-          APPLE_ID: ${{ secrets.APPLE_ID || '' }}
-          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD || '' }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID || '' }}
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY || '' }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER || '' }}
-          APPLE_API_KEY_PATH: ${{ env.APPLE_API_KEY_PATH || '' }}
-        run: npm run tauri:build -- --bundles app --target aarch64-apple-darwin
+        run: |
+          # Tauri's notarization auth selection checks only for env-var presence.
+          # Strip empty Apple auth vars so API-key auth is chosen when Apple ID
+          # secrets are unset.
+          for key in APPLE_ID APPLE_PASSWORD APPLE_TEAM_ID APPLE_API_KEY APPLE_API_ISSUER APPLE_API_PRIVATE_KEY; do
+            if [ -z "${!key:-}" ]; then
+              unset "$key"
+            fi
+          done
+
+          npm run tauri:build -- --bundles app --target aarch64-apple-darwin
 
       # ── Package artifacts ──────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- repair the macOS publish workflow so manual dispatches can build a healthy ref with the tracked `ui/package-lock.json`
- validate App Store Connect Team Key notarization inputs earlier with clearer CI errors
- strip empty Apple ID env vars before invoking Tauri so the API-key notarization path is selected correctly

## Verification
- workflow_dispatch run `24576094826` succeeded end-to-end on `ci-macos-publish-signing-flow-fix`
- signed macOS build completed
- bundle integrity verification passed
- OTA artifact upload completed in workflow_dispatch mode