### PR TITLE
Seed downstream variable contracts from Brandmint

### DIFF
--- a/brandmint/core/design_memory.py
+++ b/brandmint/core/design_memory.py
@@ -8,6 +8,27 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 
+def design_memory_anchors(contract: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Extract retrieval anchors from a downstream variable contract."""
+    if not isinstance(contract, dict):
+        return {}
+    brand = contract.get("brand_system", {}) if isinstance(contract.get("brand_system"), dict) else {}
+    visual = contract.get("visual_primitives") or contract.get("visual_system") or {}
+    if not isinstance(visual, dict):
+        visual = {}
+    assets = contract.get("asset_requirements") or contract.get("asset_plan") or {}
+    if not isinstance(assets, dict):
+        assets = {}
+    sections = contract.get("section_defaults", {}) if isinstance(contract.get("section_defaults"), dict) else {}
+    return {
+        "brand_archetype": brand.get("brand_archetype"),
+        "positioning": brand.get("positioning"),
+        "visual_primitives": visual,
+        "asset_requirements": assets.get("required", []),
+        "section_defaults": sections.get("ordered_sections", []),
+    }
+
+
 def search_design_memory(
     worker_url: str,
     *,
@@ -16,6 +37,7 @@ def search_design_memory(
     brand: Optional[str] = None,
     aspect: Optional[str] = None,
     flow: Optional[str] = None,
+    variable_contract: Optional[Dict[str, Any]] = None,
     timeout_sec: int = 10,
     require_existing: bool = True,
 ) -> List[str]:
@@ -35,6 +57,10 @@ def search_design_memory(
         payload["aspect"] = aspect
     if flow:
         payload["flow"] = flow
+    anchors = design_memory_anchors(variable_contract)
+    if anchors:
+        payload["contract"] = variable_contract
+        payload["anchors"] = anchors
 
     request = urllib.request.Request(
         f"{worker_url}/search",

--- a/brandmint/core/downstream_contract.py
+++ b/brandmint/core/downstream_contract.py
@@ -1,0 +1,125 @@
+"""Build Cambium downstream variable contracts from Brandmint state."""
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def _compact(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {k: _compact(v) for k, v in value.items() if _compact(v) not in (None, "", [], {})}
+    if isinstance(value, list):
+        return [_compact(v) for v in value if _compact(v) not in (None, "", [], {})]
+    return value
+
+
+def _first(*values: Any) -> Any:
+    for value in values:
+        if value not in (None, "", [], {}):
+            return value
+    return None
+
+
+def _as_list(value: Any) -> List[Any]:
+    if value in (None, ""):
+        return []
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _visual_assets_from_wave_plan(wave_plan: Optional[Iterable[Any]]) -> List[str]:
+    assets: List[str] = []
+    for wave in wave_plan or []:
+        if isinstance(wave, dict):
+            assets.extend(str(v) for v in wave.get("visual_assets", []) if v)
+            continue
+        values = getattr(wave, "visual_assets", [])
+        assets.extend(str(v) for v in values if v)
+    return list(dict.fromkeys(assets))
+
+
+def build_downstream_variable_contract(
+    config: Dict[str, Any],
+    skill_outputs: Optional[Dict[str, Dict[str, Any]]] = None,
+    *,
+    wave_plan: Optional[Iterable[Any]] = None,
+) -> Dict[str, Any]:
+    """Return the structured seed pack Cambium's next organs consume.
+
+    The contract is intentionally derived from existing Brandmint config and
+    skill outputs, so genesis can hand downstream organs brand, copy, visual,
+    asset, and section intent without flattening everything into prose.
+    """
+    skill_outputs = skill_outputs or {}
+    brand = config.get("brand", {}) if isinstance(config.get("brand"), dict) else {}
+    theme = config.get("theme", {}) if isinstance(config.get("theme"), dict) else {}
+    positioning = config.get("positioning", {}) if isinstance(config.get("positioning"), dict) else {}
+    palette = config.get("palette", {}) if isinstance(config.get("palette"), dict) else {}
+    typography = config.get("typography", {}) if isinstance(config.get("typography"), dict) else {}
+    aesthetic = config.get("aesthetic", {}) if isinstance(config.get("aesthetic"), dict) else {}
+    products = config.get("products", {}) if isinstance(config.get("products"), dict) else {}
+    audience = config.get("audience", {}) if isinstance(config.get("audience"), dict) else {}
+
+    campaign = skill_outputs.get("campaign-page-copy", {}).get("handoff", {})
+    visual = skill_outputs.get("visual-identity-core", {})
+    voice = skill_outputs.get("voice-and-tone", {})
+    detailed = skill_outputs.get("detailed-product-description", {})
+
+    brand_system = {
+        "name": brand.get("name"),
+        "brand_archetype": _first(brand.get("archetype"), theme.get("name"), brand.get("domain")),
+        "positioning": _first(positioning.get("statement"), skill_outputs.get("product-positioning-summary", {}).get("positioning_statement")),
+        "audience": _first(audience.get("persona_name"), skill_outputs.get("buyer-persona", {}).get("persona", {}).get("name")),
+        "voice": _first(brand.get("voice"), voice.get("voice_persona")),
+        "tone": _first(brand.get("tone"), voice.get("tone_calibration")),
+    }
+    copy_system = {
+        "hero_headline": positioning.get("hero_headline"),
+        "tagline": positioning.get("tagline"),
+        "pillars": positioning.get("pillars"),
+        "cta_primary": _first(*(campaign.get("cta_language", []) if isinstance(campaign.get("cta_language"), list) else [])),
+        "faq": campaign.get("faq"),
+    }
+    visual_primitives = {
+        "palette": palette or visual.get("color_palette"),
+        "typography": typography or visual.get("typography"),
+        "motion_style": _first(aesthetic.get("motion_style"), visual.get("motion_style")),
+        "surface_treatment": _first(aesthetic.get("hero_surface"), visual.get("imagery", {}).get("hero_surface")),
+        "hero_object_type": _first(aesthetic.get("hero_object_type"), visual.get("imagery", {}).get("hero_object_type")),
+        "logo_treatment": _first(aesthetic.get("logo_treatment"), visual.get("logo_usage", {}).get("treatment")),
+    }
+    asset_requirements = {
+        "required": list(dict.fromkeys([
+            "logo",
+            "hero_media",
+            *(_visual_assets_from_wave_plan(wave_plan)),
+            *(["product_shot"] if products.get("hero") or detailed.get("hero_product") else []),
+        ])),
+        "hero_product": _first(products.get("hero"), detailed.get("hero_product")),
+        "avoid_visual_patterns": config.get("competitive_context", {}).get("avoid_visual_patterns") if isinstance(config.get("competitive_context"), dict) else None,
+    }
+    section_defaults = {
+        "ordered_sections": ["hero", "problem", "solution", "proof", "pricing", "cta"],
+        "hero": {
+            "copy_slot": "hero_headline",
+            "asset_requirements": ["hero_media", "logo"],
+        },
+        "proof": {
+            "copy_slot": "proof_points",
+            "asset_requirements": ["product_shot"],
+        },
+        "cta": {
+            "copy_slot": "cta_primary",
+        },
+    }
+    contract = {
+        "brand_system": brand_system,
+        "copy_system": copy_system,
+        "visual_primitives": visual_primitives,
+        "visual_system": visual_primitives,
+        "asset_requirements": asset_requirements,
+        "asset_plan": asset_requirements,
+        "section_defaults": section_defaults,
+        "section_plan": section_defaults["ordered_sections"],
+    }
+    return _compact(contract)

--- a/brandmint/core/hydrator.py
+++ b/brandmint/core/hydrator.py
@@ -28,6 +28,8 @@ from typing import Any, Dict
 
 import yaml
 
+from brandmint.core.downstream_contract import build_downstream_variable_contract
+
 
 # ---------------------------------------------------------------------------
 # Hydration mapping: skill_id -> { config_dot_path: output_dot_path }
@@ -176,6 +178,8 @@ def hydrate_brand_config(config: dict, skill_outputs: Dict[str, dict]) -> dict:
             if value is not None:
                 _set_nested(config, config_path, value)
 
+    if any(skill_id in HYDRATION_MAP for skill_id in skill_outputs):
+        config["downstream_variable_contract"] = build_downstream_variable_contract(config, skill_outputs)
     return config
 
 

--- a/scripts/generate_pipeline.py
+++ b/scripts/generate_pipeline.py
@@ -24,6 +24,8 @@ try:
 except ImportError:
     pass
 
+from brandmint.core.downstream_contract import build_downstream_variable_contract
+
 
 # =====================================================================
 # REFERENCE MAP LOADING
@@ -1303,6 +1305,11 @@ def build_vars(cfg, exec_ctx=None, config_path=None):
     v["design_memory_url"] = design_memory_url
     v["design_memory_max_refs"] = int(design_memory.get("max_refs", 3) or 3)
     v["design_memory_timeout_sec"] = int(design_memory.get("timeout_sec", 10) or 10)
+    v["downstream_variable_contract_json"] = json.dumps(
+        cfg.get("downstream_variable_contract") or build_downstream_variable_contract(cfg),
+        ensure_ascii=False,
+        sort_keys=True,
+    )
     v["brandmint_repo_root"] = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 
     return v
@@ -1378,6 +1385,7 @@ def _env_int(name, default):
 
 DESIGN_MEMORY_MAX_REFS = _env_int("BRANDMINT_DESIGN_MEMORY_MAX_REFS", {design_memory_max_refs})
 DESIGN_MEMORY_TIMEOUT_SEC = _env_int("BRANDMINT_DESIGN_MEMORY_TIMEOUT_SEC", {design_memory_timeout_sec})
+DOWNSTREAM_VARIABLE_CONTRACT = {downstream_variable_contract_json}
 
 try:
     from brandmint.core.providers import get_provider as _bm_get_provider
@@ -1499,6 +1507,7 @@ def get_design_memory_refs(pid, prompt, aspect):
         limit=DESIGN_MEMORY_MAX_REFS,
         brand=BRAND_NAME,
         aspect=aspect,
+        variable_contract=DOWNSTREAM_VARIABLE_CONTRACT,
         timeout_sec=DESIGN_MEMORY_TIMEOUT_SEC,
     )
     if refs:

--- a/tests/test_design_memory.py
+++ b/tests/test_design_memory.py
@@ -4,7 +4,7 @@ import json
 from io import BytesIO
 from pathlib import Path
 
-from brandmint.core.design_memory import search_design_memory
+from brandmint.core.design_memory import design_memory_anchors, search_design_memory
 
 
 class _Response(BytesIO):
@@ -49,3 +49,38 @@ def test_search_design_memory_posts_query_and_returns_existing_paths(monkeypatch
 
 def test_search_design_memory_returns_empty_without_url() -> None:
     assert search_design_memory("", query="anything") == []
+
+
+def test_design_memory_payload_includes_downstream_contract_anchors(monkeypatch, tmp_path: Path) -> None:
+    ref = tmp_path / "reference.png"
+    ref.write_bytes(b"png")
+    calls = []
+
+    def fake_urlopen(request, timeout):  # type: ignore[no-untyped-def]
+        calls.append((request, timeout))
+        return _Response(json.dumps({"results": [{"asset": {"path": str(ref)}}]}).encode("utf-8"))
+
+    monkeypatch.setattr("brandmint.core.design_memory.urllib.request.urlopen", fake_urlopen)
+
+    contract = {
+        "brand_system": {"brand_archetype": "company-compiler", "positioning": "Idea in. Venture out."},
+        "visual_primitives": {"hero_object_type": "living tree-ring map"},
+        "asset_requirements": {"required": ["logo", "hero_media"]},
+        "section_defaults": {"ordered_sections": ["hero", "proof", "cta"]},
+    }
+    paths = search_design_memory(
+        "https://worker.example",
+        query="tree-ring tactical map",
+        variable_contract=contract,
+        require_existing=True,
+    )
+
+    assert paths == [str(ref)]
+    payload = json.loads(calls[0][0].data.decode("utf-8"))
+    assert payload["contract"] == contract
+    assert payload["anchors"]["brand_archetype"] == "company-compiler"
+    assert payload["anchors"]["asset_requirements"] == ["logo", "hero_media"]
+
+
+def test_design_memory_anchors_ignore_empty_contract() -> None:
+    assert design_memory_anchors(None) == {}

--- a/tests/test_downstream_contract.py
+++ b/tests/test_downstream_contract.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+from brandmint.core.downstream_contract import build_downstream_variable_contract
+
+
+def sample_brand_config() -> dict:
+    return {
+        "brand": {
+            "name": "Cambium",
+            "archetype": "company-compiler",
+            "voice": "direct, vivid, precise",
+            "tone": "warm operational clarity",
+        },
+        "audience": {"persona_name": "founder-operator"},
+        "positioning": {
+            "statement": "Turn a thoughtseed into a running company.",
+            "hero_headline": "Compile the company",
+            "tagline": "Idea in. Venture out.",
+            "pillars": ["composition", "taste", "memory"],
+        },
+        "palette": {
+            "primary": {"name": "Cambium Green", "hex": "#3C7A4B"},
+            "accent": {"name": "Signal Gold", "hex": "#E0B84C"},
+        },
+        "typography": {"header": {"font": "Figtree"}, "body": {"font": "Inter"}},
+        "aesthetic": {
+            "hero_object_type": "living tree-ring map",
+            "hero_surface": "tactile woven substrate",
+            "logo_treatment": "embossed seal",
+        },
+        "products": {"hero": {"name": "Cambium operator", "description": "Self-running venture OS"}},
+    }
+
+
+def test_brandmint_outputs_downstream_seed_variables() -> None:
+    result = build_downstream_variable_contract(sample_brand_config())
+
+    assert result["brand_system"]["brand_archetype"] == "company-compiler"
+    assert result["brand_system"]["positioning"] == "Turn a thoughtseed into a running company."
+    assert "copy_system" in result
+    assert result["copy_system"]["hero_headline"] == "Compile the company"
+    assert "visual_primitives" in result
+    assert result["visual_primitives"]["hero_object_type"] == "living tree-ring map"
+    assert "asset_requirements" in result
+    assert "logo" in result["asset_requirements"]["required"]
+    assert "hero_media" in result["asset_requirements"]["required"]
+    assert result["section_defaults"]["ordered_sections"] == ["hero", "problem", "solution", "proof", "pricing", "cta"]
+
+
+def test_downstream_seed_pack_includes_cambium_aliases() -> None:
+    result = build_downstream_variable_contract(sample_brand_config())
+
+    assert result["visual_system"] == result["visual_primitives"]
+    assert result["asset_plan"] == result["asset_requirements"]
+    assert result["section_plan"] == result["section_defaults"]["ordered_sections"]
+
+
+def test_wave_plan_visual_assets_feed_asset_requirements() -> None:
+    result = build_downstream_variable_contract(
+        sample_brand_config(),
+        wave_plan=[{"visual_assets": ["2A", "3B", "APP-SCREENSHOT"]}],
+    )
+
+    assert "2A" in result["asset_requirements"]["required"]
+    assert "3B" in result["asset_requirements"]["required"]
+    assert "APP-SCREENSHOT" in result["asset_requirements"]["required"]

--- a/tests/test_generate_pipeline_template.py
+++ b/tests/test_generate_pipeline_template.py
@@ -74,7 +74,9 @@ def test_template_queries_design_memory_before_provider_generation() -> None:
 
     assert "from brandmint.core.design_memory import search_design_memory" in src
     assert "DESIGN_MEMORY_URL =" in src
+    assert "DOWNSTREAM_VARIABLE_CONTRACT =" in src
     assert "def get_design_memory_refs(pid, prompt, aspect):" in src
+    assert "variable_contract=DOWNSTREAM_VARIABLE_CONTRACT" in src
     assert "image_urls.extend(get_design_memory_refs(pid, prompt, aspect))" in src
 
 

--- a/tests/test_hydrator.py
+++ b/tests/test_hydrator.py
@@ -305,6 +305,8 @@ class TestHydrateBrandConfig:
         assert result["audience"]["persona_name"] == "The Adventurous Explorer"
         assert result["positioning"]["hero_headline"] == "Travel Like a Local"
         assert len(result["positioning"]["pillars"]) == 3
+        assert result["downstream_variable_contract"]["brand_system"]["voice"] == "The Confident Local Friend"
+        assert "asset_requirements" in result["downstream_variable_contract"]
 
     def test_modifies_in_place(self, empty_config, voice_tone_output):
         outputs = {"voice-and-tone": voice_tone_output}


### PR DESCRIPTION
## Summary
- add a pure downstream variable-contract builder for Brandmint genesis output
- attach `downstream_variable_contract` during known-skill hydration so brand-config serialization carries the seed pack
- extend Design Memory search payloads with contract anchors (`brand_archetype`, positioning, visual primitives, asset requirements, section defaults)
- update generated visual pipelines to pass the downstream contract into Design Memory retrieval

## Why
Cambium's fractal-tapestry contract layer expects Brandmint/genesis to seed downstream variables deliberately instead of flattening brand truth into prose. This PR gives Brandmint a structured seed pack for brand, copy, visual, asset, and section intent while preserving existing behavior for empty/unknown hydration inputs.

## Verification
- `pytest -q tests/test_downstream_contract.py tests/test_hydrator.py tests/test_design_memory.py` — 47 pass
- `pytest -q tests/test_downstream_contract.py tests/test_hydrator.py tests/test_design_memory.py tests/test_generate_pipeline_template.py` — 56 pass

## Full-suite caveat
- `pytest -q` currently stops during collection because this clean worktree environment is missing project dependencies such as `rich` and `typer`. The focused Task 6 tests above do not require those optional/runtime CLI dependencies.
